### PR TITLE
get_events(): Replace "clever" code with a for loop

### DIFF
--- a/automated_tickets_lib.py
+++ b/automated_tickets_lib.py
@@ -442,7 +442,13 @@ def get_events(settings, event_schedule):
     for event in mysql_cursor.fetchall():
 
         # Prune whitespace from all fields
-        event = tuple([item.strip() if isinstance(item, str) else item for item in event])
+        # event = tuple([item.strip() else item for item in event])
+        fields = []
+        for field in event:
+            if isinstance(field, str):
+                field = field.strip()
+            fields.append(field)
+        event = tuple(fields)
 
         # Collect a list of all events we need to take action for
         events.append(Event(event))


### PR DESCRIPTION
Evidently I don't have the prior list comprehension code quite right as the results do not include both stripped text fields in addition to other object types. Replaced with a classic for loop and if statement to achieve the desired results.

closes WhyAskWhy/automated-tickets#16
