### PR TITLE
I18 add weekly weekend frequencies

### DIFF
--- a/automated_tickets.py
+++ b/automated_tickets.py
@@ -77,6 +77,8 @@ parser.add_argument(
         'weekly_wednesday',
         'weekly_thursday',
         'weekly_friday',
+        'weekly_saturday',
+        'weekly_sunday',
         'weekly',
         'twice_month',
         'monthly',

--- a/automated_tickets.py
+++ b/automated_tickets.py
@@ -63,29 +63,13 @@ parser = argparse.ArgumentParser(
     )
 
 # This will need to be broken up later by the script
-# WARNING: This needs to be kept in sync with DATE_LABEL within
-# the library file.
 parser.add_argument(
     '--event_schedule',
     action='store',
     required=True,
-    choices=[
-        'daily',
-        'twice_week',
-        'weekly_monday',
-        'weekly_tuesday',
-        'weekly_wednesday',
-        'weekly_thursday',
-        'weekly_friday',
-        'weekly_saturday',
-        'weekly_sunday',
-        'weekly',
-        'twice_month',
-        'monthly',
-        'twice_year',
-        'quarterly',
-        'yearly'
-    ]
+
+    # Reuse keys from DATE_LABEL dict in library file instead of repeating here
+    choices=list(DATE_LABEL.keys())
 )
 
 # NOTE: Probably want to leave this as not required and fall back to checking

--- a/automated_tickets_lib.py
+++ b/automated_tickets_lib.py
@@ -78,10 +78,10 @@ YEAR = date.strftime('%Y')
 # we will get the same result as what we're doing here
 TODAY = date.strftime('%Y-%m-%d')
 
-# These entries match up with the event schedule "keywords". For example,
-# when daily events are requested, active daily events will result in
-# notifications generated which have subject lines that include the value
-# that is paired with the keyword below.
+# These entries serve both as a mapping of display formats and also as
+# valid parameter values. For example, when daily events are requested,
+# active daily events will result in notifications generated which have
+# subject lines that include the value that is paired with the keyword below.
 DATE_LABEL = {
     'daily':TODAY,
     'twice_week':TODAY,

--- a/automated_tickets_lib.py
+++ b/automated_tickets_lib.py
@@ -91,6 +91,8 @@ DATE_LABEL = {
     'weekly_wednesday':TODAY,
     'weekly_thursday':TODAY,
     'weekly_friday':TODAY,
+    'weekly_saturday':TODAY,
+    'weekly_sunday':TODAY,
     'twice_month':TODAY,
     'monthly':MONTH_YEAR,
     'twice_year':MONTH_YEAR,


### PR DESCRIPTION
- Add missing `weekly_saturday` and `weekly_sunday` frequencies
- Dedupe command-line parameter list by re-using DATE_LABEL dictionary keys

closes WhyAskWhy/automated-tickets#18