### PR TITLE
Remove ref to MySQLdb, affirm mysql.connector

### DIFF
--- a/automated_tickets_lib.py
+++ b/automated_tickets_lib.py
@@ -21,14 +21,14 @@ import sys
 # Modules - Third party
 ########################################
 
-# Third-party module
-# https://pypi.python.org/pypi/MySQL-python/1.2.5
-# apt-get install python-mysqldb
-#import MySQLdb
-
-# Upstream module, recommended by MariaDB documentation
-# https://dev.mysql.com/downloads/repo/apt/
-# apt-get install mysql-connector-python
+# Upstream module, actively maintained and official recommendation
+# of the MariaDB project (per their documentation).
+# Available via OS packages (including apt repo) or pip.
+#
+# Examples:
+#
+# * sudo apt-get install mysql-connector-python
+# * pip install mysql-connector-python --user
 import mysql.connector as mysql
 
 

--- a/references.md
+++ b/references.md
@@ -22,7 +22,11 @@
 
 - https://dev.mysql.com/downloads/repo/apt/
 - https://dev.mysql.com/doc/mysql-apt-repo-quick-guide/en/
-- https://dev.mysql.com/downloads/connector/python/2.1.html
+
+- https://dev.mysql.com/doc/connector-python/en/
+- https://pypi.org/project/mysql-connector-python/
+
+
 
 ### SQLite
 


### PR DESCRIPTION
- Remove refs to MySQLdb since it does not appear to be
  actively maintained (and we are not currently using it)

- Add additional notes for mysql-connector-python
    - Upstream ref links
    - Note that it is actively maintained
    - pip installation option

closes WhyAskWhy/automated-tickets#2