### PR TITLE
Replace print calls with logging module

### DIFF
--- a/automated_tickets.ini
+++ b/automated_tickets.ini
@@ -15,31 +15,28 @@
 ############################################################
 
 # Disables sending notifications and any other possibly destructive action
-testing_mode = true
+testing_mode = false
 
-# Set to true for verbose output as the script executes. Useful for troubleshooting.
-display_debug_messages = true
+# Set to true for verbose output to the current console/terminal as the script
+# executes. Useful for troubleshooting.
+display_console_debug_messages = false
 
 # Less verbose output. Enabling this provides status details.
-display_info_messages = true
+display_console_info_messages = false
 
 # Output warning messages which indicate that a desired step was not
 # completed as expected, but the issue does not appear to be severe
 # enough to stop the script from completing in an "acceptable" manner.
-# See the 'fail_on_warnings' option in case you would rather not
-# continue operation when warning conditions are encountered
-# TODO: Add support for this
-display_warning_messages = true
+display_console_warning_messages = false
 
 # Output error messages which block proper operation of the script
-# TODO: Add support for this
-display_error_messages = true
+display_console_error_messages = false
 
 # If enabled, this treats all warnings as failures and exits immediately with
 # one or more messages indicating that this option is enabled and what warning
 # condition occured
 # TODO: Add support for this
-fail_on_warnings = false
+# fail_on_warnings = false
 
 # If enabled, events/tasks that are flagged as an intern_task are processed
 # like all other matching events. If false, then those events are filtered out

--- a/references.md
+++ b/references.md
@@ -26,7 +26,12 @@
 - https://dev.mysql.com/doc/connector-python/en/
 - https://pypi.org/project/mysql-connector-python/
 
+### Logging
 
+- https://docs.python.org/3/library/logging.handlers.html
+- https://docs.python.org/3/library/logging.html
+- https://stackoverflow.com/questions/3968669/how-to-configure-logging-to-syslog-in-python
+- [Writing to syslog with Python's logging library](https://gist.github.com/sweenzor/1782457)
 
 ### SQLite
 


### PR DESCRIPTION
More work to do later, but the current state relies upon the standard library logging module and related config settings to control output.

Future work will likely result in related logging settings being moved to an external config file to make it easier to modify specific log settings.

closes WhyAskWhy/automated-tickets#21